### PR TITLE
Typo in variable name: wv.close() --> wf.close()

### DIFF
--- a/nesmdb/vgm/vgm_to_wav.py
+++ b/nesmdb/vgm/vgm_to_wav.py
@@ -65,7 +65,7 @@ def vgm_to_wav(vgm):
   res = subprocess.call('{} --loop-count 1 {} {}'.format(bin_fp, vf.name, wf.name).split())
   if res > 0:
     vf.close()
-    wv.close()
+    wf.close()
     raise Exception('Invalid return code {} from vgm2wav'.format(res))
 
   vf.close()


### PR DESCRIPTION
flake8 testing of https://github.com/chrisdonahue/nesmdb on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./nesmdb/vgm/vgm_to_wav.py:68:5: F821 undefined name 'wv'
    wv.close()
    ^
1     F821 undefined name 'wv'
1
```