### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
+*.swp
+*.DS_Store
+build
 nesmdb.egg-info

--- a/nesmdb/__init__.py
+++ b/nesmdb/__init__.py
@@ -1,3 +1,4 @@
-import apu
-import convert
-import cycle
+from __future__ import absolute_import
+from . import apu
+from . import convert
+from . import cycle

--- a/nesmdb/apu.py
+++ b/nesmdb/apu.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 # System master clock rates by console region
 ntsc_clock = (21477272. / 12.) # ~1789772.67
 pal_clock = 1662607.
@@ -144,7 +146,7 @@ register_function_bitmasks['p2'] = register_function_bitmasks['p1']
 
 
 def func_to_bitmask(ch, fu):
-  for offset, bitmasks in register_function_bitmasks[ch].items():
+  for offset, bitmasks in list(register_function_bitmasks[ch].items()):
     for fu_name, bitmask in bitmasks:
       if fu_name == fu:
         return bitmask
@@ -159,7 +161,7 @@ def func_to_max(ch, fu):
 
 
 def func_to_offset(ch, fu):
-  for offset, bitmasks in register_function_bitmasks[ch].items():
+  for offset, bitmasks in list(register_function_bitmasks[ch].items()):
     for fu_name, bitmask in bitmasks:
       if fu_name == fu:
         return offset

--- a/nesmdb/convert.py
+++ b/nesmdb/convert.py
@@ -1,9 +1,14 @@
-import cPickle as pickle
 import os
+
+try:
+  # python 2
+  import pickle as pickle
+except:
+  # python 3
+  import pickle as pickle
 
 import numpy as np
 from scipy.io.wavfile import write as wavwrite
-from scipy.misc import imsave as imwrite
 
 import nesmdb.vgm
 import nesmdb.score
@@ -252,7 +257,7 @@ def main():
       'midi_to_wav': ['midi_to_wav_rate'],
   }
 
-  parser.add_argument('conversion', type=str, choices=conversion_to_types.keys())
+  parser.add_argument('conversion', type=str, choices=list(conversion_to_types.keys()))
   parser.add_argument('fps', type=str, nargs='+')
   parser.add_argument('--out_dir', type=str)
   parser.add_argument('--skip_verify', action='store_true', dest='skip_verify')
@@ -294,11 +299,11 @@ def main():
     out_fps = [os.path.join(args.out_dir, fn) for fn in out_fns]
 
     if os.path.exists(args.out_dir):
-      print 'WARNING: Output directory {} already exists'.format(args.out_dir)
+      print('WARNING: Output directory {} already exists'.format(args.out_dir))
     else:
       os.makedirs(args.out_dir)
 
-  for in_fp, out_fp in tqdm(zip(fps, out_fps)):
+  for in_fp, out_fp in tqdm(list(zip(fps, out_fps))):
     if not args.skip_verify:
       _verify_type(in_fp, in_type)
       _verify_type(out_fp, out_type)
@@ -324,8 +329,8 @@ def main():
     try:
       out_file = globals()[args.conversion](in_file, **kwargs)
     except:
-      print '-' * 80
-      print in_fp
+      print('-' * 80)
+      print(in_fp)
       traceback.print_exc()
       continue
 

--- a/nesmdb/cycle.py
+++ b/nesmdb/cycle.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
   args = parser.parse_args()
 
   if args.representation not in ['ndr', 'ndf', 'nlm', 'rawsco'] and args.score_rate is None:
-    print 'Must specify --score_rate'
+    print('Must specify --score_rate')
     sys.exit(1)
 
   kwargs = {'score_rate': args.score_rate}
@@ -169,14 +169,14 @@ if __name__ == '__main__':
     try:
       cycle_vgm = vgm_cycle(source_vgm, representation=args.representation, **kwargs)
     except:
-      print '-' * 80
-      print vgm_fp
-      print traceback.print_exc()
+      print('-' * 80)
+      print(vgm_fp)
+      print(traceback.print_exc())
       continue
 
     dist, source_wav, cycle_wav = vgm_dist(source_vgm, cycle_vgm)
     vgm_fp_to_dist[vgm_fp] = dist
-    
+
     if args.keep_vgm:
       with open(vgm_fp.replace('.vgm', '.source.vgm'), 'wb') as f:
         f.write(source_vgm)
@@ -187,14 +187,14 @@ if __name__ == '__main__':
       nesmdb.vgm.save_vgmwav(vgm_fp.replace('.vgm', '.source.wav'), source_wav)
       nesmdb.vgm.save_vgmwav(vgm_fp.replace('.vgm', '.cycle.wav'), cycle_wav)
 
-  dists = vgm_fp_to_dist.values()
-  print 'Mean distance (n={}): {} (std={})'.format(len(dists), np.mean(dists), np.std(dists))
+  dists = list(vgm_fp_to_dist.values())
+  print('Mean distance (n={}): {} (std={})'.format(len(dists), np.mean(dists), np.std(dists)))
 
   if not args.quiet:
-    print '-' * 40 + ' Worst ' + '-' * 40
-    for vgm_fp, dist in sorted(vgm_fp_to_dist.items(), key=lambda x:-x[1])[:8]:
-      print '{:.8f}: {}'.format(dist, vgm_fp)
+    print('-' * 40 + ' Worst ' + '-' * 40)
+    for vgm_fp, dist in sorted(list(vgm_fp_to_dist.items()), key=lambda x:-x[1])[:8]:
+      print('{:.8f}: {}'.format(dist, vgm_fp))
 
-    print '-' * 40 + ' Best ' + '-' * 40
-    for vgm_fp, dist in sorted(vgm_fp_to_dist.items(), key=lambda x:x[1])[:8]:
-      print '{:.8f}: {}'.format(dist, vgm_fp)
+    print('-' * 40 + ' Best ' + '-' * 40)
+    for vgm_fp, dist in sorted(list(vgm_fp_to_dist.items()), key=lambda x:x[1])[:8]:
+      print('{:.8f}: {}'.format(dist, vgm_fp))

--- a/nesmdb/score/__init__.py
+++ b/nesmdb/score/__init__.py
@@ -1,5 +1,6 @@
-from rawsco import ndf_to_rawsco, rawsco_to_ndf
-from exprsco import rawsco_to_exprsco, exprsco_downsample, exprsco_to_rawsco
-from seprsco import exprsco_to_seprsco, seprsco_to_exprsco
-from blndsco import exprsco_to_blndsco, blndsco_to_exprsco
-from midi import exprsco_to_midi, midi_to_exprsco
+from __future__ import absolute_import
+from .rawsco import ndf_to_rawsco, rawsco_to_ndf
+from .exprsco import rawsco_to_exprsco, exprsco_downsample, exprsco_to_rawsco
+from .seprsco import exprsco_to_seprsco, seprsco_to_exprsco
+from .blndsco import exprsco_to_blndsco, blndsco_to_exprsco
+from .midi import exprsco_to_midi, midi_to_exprsco

--- a/nesmdb/score/blndsco.py
+++ b/nesmdb/score/blndsco.py
@@ -5,9 +5,9 @@ def exprsco_to_blndsco(exprsco):
   rate, nsamps, score = exprsco
 
   blndsco = []
-  for i in xrange(score.shape[0]):
+  for i in range(score.shape[0]):
     score_slice = list(score[i, :3, 0])
-    score_slice = sorted(filter(lambda x: x > 0, score_slice))
+    score_slice = sorted([x for x in score_slice if x > 0])
     blndsco.append(score_slice)
 
   return (rate, nsamps, blndsco)

--- a/nesmdb/score/exprsco.py
+++ b/nesmdb/score/exprsco.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from collections import defaultdict, Counter
 import math
 
@@ -54,10 +55,10 @@ def exprsco_downsample(exprsco, rate, adaptive):
 
   if rate is None:
     # Find note onsets
-    ch_to_last_note = {ch:0 for ch in xrange(4)}
+    ch_to_last_note = {ch:0 for ch in range(4)}
     ch_to_onsets = defaultdict(list)
-    for i in xrange(exprsco.shape[0]):
-      for j in xrange(4):
+    for i in range(exprsco.shape[0]):
+      for j in range(4):
         last_note = ch_to_last_note[j]
         note = exprsco[i, j, 0]
         if note > 0 and note != last_note:
@@ -66,13 +67,13 @@ def exprsco_downsample(exprsco, rate, adaptive):
 
     # Find note intervals
     intervals = Counter()
-    for _, onsets in ch_to_onsets.items():
-      for i in xrange(1, len(onsets)):
+    for _, onsets in list(ch_to_onsets.items()):
+      for i in range(1, len(onsets)):
         interval = onsets[i] - onsets[i - 1]
         # Minimum length 1ms
         if interval > 44:
           intervals[interval] += 1
-    intervals_t = {i / 44100.:c for i, c in intervals.items()}
+    intervals_t = {i / 44100.:c for i, c in list(intervals.items())}
 
     # Raise error if we don't have enough info to estimate tempo
     num_intervals = sum(intervals.values())
@@ -85,7 +86,7 @@ def exprsco_downsample(exprsco, rate, adaptive):
     rate_errors = []
     for rate in np.arange(1., 24. + disc, disc):
       error = 0.
-      for interval, count in intervals_t.items():
+      for interval, count in list(intervals_t.items()):
         quotient = math.floor(interval * rate + 1e-8)
         remainder = interval - (quotient / rate)
         if remainder < 0 and abs(remainder) < 1e-8:
@@ -102,13 +103,13 @@ def exprsco_downsample(exprsco, rate, adaptive):
   rate = float(rate)
   ndown = int((nsamps / 44100.) * rate)
   score_low = np.zeros((ndown, 4, 3), dtype=np.uint8)
-  for i in xrange(ndown):
+  for i in range(ndown):
     t_lo = i / rate
     t_hi = (i + 1) / rate
     # TODO: round these instead of casting?
     samp_lo, samp_hi = [int(t * 44100.) for t in [t_lo, t_hi]]
     score_slice = exprsco[samp_lo:samp_hi]
-    for ch in xrange(4):
+    for ch in range(4):
       score_slice_ch = score_slice[:, ch, :]
       on_frames = np.where(score_slice_ch[:, 0] != 0)[0]
       if len(on_frames) > 0:

--- a/nesmdb/score/midi.py
+++ b/nesmdb/score/midi.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from collections import defaultdict
 import numpy as np
 import tempfile
@@ -60,7 +61,7 @@ def exprsco_to_midi(exprsco):
       note_ends.append(s + 1)
 
     assert len(note_starts) == len(note_ends)
-    notes[i] = zip(note_starts, note_ends)
+    notes[i] = list(zip(note_starts, note_ends))
     ccs[i] = ch_ccs
 
   # Add notes to MIDI instruments
@@ -140,7 +141,7 @@ def midi_to_exprsco(midi):
     note = 0
     velocity = 0
     timbre = 0
-    for i in xrange(nsamps):
+    for i in range(nsamps):
       for comm in comms[i]:
         if comm[0] == 'note_on':
           note = comm[1]

--- a/nesmdb/score/rawsco.py
+++ b/nesmdb/score/rawsco.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from collections import defaultdict, Counter
 
 import numpy as np
@@ -82,7 +83,7 @@ def ndf_to_rawsco(ndf):
     ch_to_stimer[ch] = ch_to_timer[ch] + shifted
 
   # Extract musical transcript by emulating APU
-  for samp in xrange(nsamps):
+  for samp in range(nsamps):
     # Frame counter (in between samples)
     quarter_frame = False
     half_frame = False
@@ -285,7 +286,7 @@ def rawsco_to_ndf(rawsco):
   last_no_np = 0
   last_no_nl = 0
 
-  for i in xrange(max_i):
+  for i in range(max_i):
     for j, ch in enumerate(['p1', 'p2']):
       th, tl, volume, du = score[i, j]
       timer = (th << 8) + tl

--- a/nesmdb/tests/test_formats.py
+++ b/nesmdb/tests/test_formats.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import glob
 import os
 from unittest import TestCase

--- a/nesmdb/vgm/__init__.py
+++ b/nesmdb/vgm/__init__.py
@@ -1,6 +1,6 @@
-from vgm_ndr import vgm_to_ndr, ndr_to_vgm
-from ndr_ndf import ndr_to_ndf, ndf_to_ndr
-from ndf_nlm import ndf_to_nlm, nlm_to_ndf
-from nd_txt import nd_to_txt, txt_to_nd
-from vgm_simplify import vgm_simplify, vgm_shorten
-from vgm_to_wav import vgm_to_wav, load_vgmwav, save_vgmwav
+from .vgm_ndr import vgm_to_ndr, ndr_to_vgm
+from .ndr_ndf import ndr_to_ndf, ndf_to_ndr
+from .ndf_nlm import ndf_to_nlm, nlm_to_ndf
+from .nd_txt import nd_to_txt, txt_to_nd
+from .vgm_simplify import vgm_simplify, vgm_shorten
+from .vgm_to_wav import vgm_to_wav, load_vgmwav, save_vgmwav

--- a/nesmdb/vgm/bintypes.py
+++ b/nesmdb/vgm/bintypes.py
@@ -6,22 +6,25 @@ b2h = lambda x: binascii.hexlify(x)
 h2b = lambda x: binascii.unhexlify(x)
 
 # Bytes to 4-byte ([l]ittle/[b]ig) unsigned ints
-b2lu = lambda x: struct.unpack('<I', x)[0]
-b2bu = lambda x: struct.unpack('>I', x)[0]
+b2lu = lambda x: struct.unpack('<I', x)[0:1]
+b2bu = lambda x: struct.unpack('>I', x)[0:1]
 i2lub = lambda x: struct.pack('<I', x)
 i2bub = lambda x: struct.pack('>I', x)
 
 # Bytes to 2-byte ([l]ittle/[b]ig) unsigned shorts
-b2lus = lambda x: struct.unpack('<H', x)[0]
-b2bus = lambda x: struct.unpack('>H', x)[0]
+b2lus = lambda x: struct.unpack('<H', x)[0:1]
+b2bus = lambda x: struct.unpack('>H', x)[0:1]
 i2lusb = lambda x: struct.pack('<H', x)
 i2busb = lambda x: struct.pack('>H', x)
 
 # String to 1-byte chars
-b2c = lambda x: struct.unpack('B', x)[0]
-c2b = lambda x: struct.pack('B', x)[0]
+b2c = lambda x: struct.unpack('B', x)[0:1]
+c2b = lambda x: struct.pack('B', x)[0:1]
 
 # Pointer arithmetic
 b2p = lambda x: b2h(i2bub(b2lu(x)))
 offset = lambda x, y: b2h(i2bub(b2bu(h2b(x)) + y))
 read = lambda x, y: x[b2bu(h2b(y)):]
+
+# Int to 1-byte chars
+int2b = lambda x: c2b(x) if isinstance(x, int) else x

--- a/nesmdb/vgm/nd_txt.py
+++ b/nesmdb/vgm/nd_txt.py
@@ -1,5 +1,5 @@
 def nd_to_txt(nd):
-  txt = filter(lambda c: c[0] != 'ram', nd)
+  txt = [c for c in nd if c[0] != 'ram']
   txt = [','.join([str(f) for f in c]) for c in txt]
   txt = '\n'.join(txt)
 

--- a/nesmdb/vgm/ndr_ndf.py
+++ b/nesmdb/vgm/ndr_ndf.py
@@ -152,7 +152,7 @@ def ndf_to_ndr(ndf):
   for comm in ndf:
     itype = comm[0]
     if itype == 'wait':
-      for _, (arg1, arg2) in regn_to_val.items():
+      for _, (arg1, arg2) in list(regn_to_val.items()):
         ndr.append(('apu', b2h(c2b(arg1)), b2h(c2b(arg2))))
       regn_to_val = OrderedDict()
 
@@ -193,7 +193,7 @@ def ndf_to_ndr(ndf):
     else:
       raise NotImplementedError()
 
-  for _, (arg1, arg2) in regn_to_val.items():
+  for _, (arg1, arg2) in list(regn_to_val.items()):
     ndr.append(('apu', b2h(c2b(arg1)), b2h(c2b(arg2))))
 
   return ndr

--- a/nesmdb/vgm/vgm_ndr.py
+++ b/nesmdb/vgm/vgm_ndr.py
@@ -1,7 +1,6 @@
 from nesmdb.apu import *
 from nesmdb.vgm.bintypes import *
 
-
 def vgm_to_ndr(vgm):
   # Retrieve EOF offset
   eof_offset = offset(b2p(vgm[0x04:0x08]), 0x04)
@@ -154,9 +153,8 @@ def ndr_to_vgm(ndr):
 
   ndr = ndr[1:]
 
-  EMPTYBYTE = i2lub(0)
-  flatten = lambda vgm: list(''.join(vgm))
-  vgm = flatten([EMPTYBYTE] * 48)
+  flatten = lambda x: list(b''.join([int2b(i) for i in x]))
+  vgm = [c2b(0) for i in range(48*4)]
 
   # VGM identifier
   vgm[:0x04] = [c2b(c) for c in [0x56, 0x67, 0x6d, 0x20]]
@@ -166,6 +164,9 @@ def ndr_to_vgm(ndr):
   vgm[0x84:0x88] = i2lub(clock)
   # Data offset
   vgm[0x34:0x38] = i2lub(0xc0 - 0x34)
+
+  # convert array to bytes
+  vgm = [int2b(i) for i in vgm]
 
   wait_sum = 0
   for comm in ndr:
@@ -201,5 +202,5 @@ def ndr_to_vgm(ndr):
   # EoF offset
   vgm[0x04:0x08] = i2lub(len(vgm) - 0x04)
 
-  vgm = ''.join(vgm)
+  vgm = b''.join([int2b(i) for i in vgm])
   return vgm

--- a/nesmdb/vgm/vgm_simplify.py
+++ b/nesmdb/vgm/vgm_simplify.py
@@ -38,7 +38,7 @@ def vgm_simplify(vgm, nop1=False, nop2=False, notr=False, nono=False, nodm=True)
     b = vgm[i]
     bhex = b2h(b)
     if bhex == '54':
-      delidxs.extend(range(i, i + 3))
+      delidxs.extend(list(range(i, i + 3)))
       i += 3
     elif bhex == '61':
       i += 3
@@ -48,19 +48,19 @@ def vgm_simplify(vgm, nop1=False, nop2=False, notr=False, nono=False, nodm=True)
       break
     elif bhex == '67':
       data_size = b2lu(''.join(vgm[i+3:i+7]))
-      delidxs.extend(range(i, i + 3 + 4 + data_size))
+      delidxs.extend(list(range(i, i + 3 + 4 + data_size)))
       delcmds += 1
       i += 3 + 4 + data_size
     elif bhex[0] == '7':
       i += 1
     elif bhex == 'a0':
-      delidxs.extend(range(i, i + 3))
+      delidxs.extend(list(range(i, i + 3)))
       i += 3
     elif bhex == 'b4':
       arg1 = vgm[i+1]
       arg1hex = b2h(arg1)
       if arg1hex not in valid_registers:
-        delidxs.extend(range(i, i + 3))
+        delidxs.extend(list(range(i, i + 3)))
         delcmds += 1
       i += 3
     else:

--- a/nesmdb/vgm/vgm_to_wav.py
+++ b/nesmdb/vgm/vgm_to_wav.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import distutils.spawn
 import os
 import subprocess


### PR DESCRIPTION
Hello, thanks very much for this really incredible work! I've been reading some of your papers (including your dissertation, which is really fantastic!) and have learned a great deal from your writing. I have lots of questions on downstream machine learning tasks but this probably isn't the place for those...

I was hoping to use this library for some work in Python 3, and it looked like a few folks started some pull requests to offer Python 3 support, but none had quite sorted out the differences between byte sequence data in Python 2 and 3, so I wanted to give it a go.

In any event, this PR offers Python 3 support for the library. I also updated the setup.py file to allow users with OSX machines to install the VGMPlay dependency. 

I also made the questionable decision to remove the errors that used to spring when one failed to build VGMPlay. My thought was that, rather than force e.g. Windows users to have to hack the VGMPlay Makefile in setup.py, maybe it'd make sense to let users compile VGMPlay and then just move the executable to the location on the filesystem where this library is located after installation. That way users like the Windows OS user in the issue tracker could compile the executable using whatever means necessary and then just move the executable to the proper location for use by this library.

In any event I'm happy to change any element of this if you like. Either way thanks again for this great work!

![e729d847c3b8b879-1up-mario-mushroom-nes-gifs-get-the-best-gif-on-giphy](https://user-images.githubusercontent.com/4801116/83340471-9ec1e700-a2a6-11ea-8fad-796ebd730412.gif)
